### PR TITLE
don't auto-start web audio

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -26,6 +26,21 @@ h1 {
   margin:0 0 0 0;
 }
 
+#start-cover {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    background: black;
+    z-index: 1000;
+}
+.simple-button.start {
+    width: 20%;
+    margin-left: 40%;
+    margin-top: 10%;
+}
+
 .info {
   color:#444;
   font-style:italic;

--- a/index.html
+++ b/index.html
@@ -28,6 +28,11 @@
     <link rel="stylesheet" type="text/css" href="css/jquery.minicolors.css" />
   </head>
   <body>
+    <div id="start-cover">
+      <button class="simple-button start" style="display: none;">
+        Start
+      </button>
+    </div>
     <div class="container">
       <div class="controls">
         <div class="buttons">

--- a/js/app.js
+++ b/js/app.js
@@ -41,7 +41,12 @@ lissa.init = function($) {
 };
 
 (function($){
-  $(document).ready(function(){
-    lissa.init($);
-  });
+  window.onload = function() {
+    $('.simple-button.start').click(function(){
+      $('#start-cover').css('display', 'none');
+      lissa.init($);
+    });
+    // only show the start button once clicking it will actually do something
+    $('.simple-button.start').css('display', 'inline');
+  };
 })(jQuery);


### PR DESCRIPTION
I found that, about half the time, loading tytel.org/lissa would have no audio. This was because of https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#webaudio

To comply with this, I changed it so the user has to click "start" and then the web audio starts. 

It's kind of a heavy handed fix, but it's obvious to the user what to do, and it means all the existing Lissa app can stay the same.

What do you think?